### PR TITLE
Micrometer for prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
 
 		<!-- Database -->
 		<dependency>
@@ -253,6 +257,13 @@
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>2.9.2</version>
 		</dependency>
+
+		<!-- Prometheus Metrics -->
+		<dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.6.6</version>
+        </dependency>
 
 		<!-- Keycloak -->
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,6 @@ logging.config=${fr.insee.queen.logging.path}
 logging.level.root=${fr.insee.queen.logging.level}
 
 logging.level.liquibase=ERROR
+
+#Metrics configuration
+management.endpoints.web.exposure.include=info, health, prometheus


### PR DESCRIPTION
This feature enables Micrometer which exposes Actuator metrics to external monitoring systems Prometheus.