### PR TITLE
ci: add docker temp folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY ./target/*.jar /opt/app/app.jar
 # Setup a non-root user context (security)
 RUN addgroup -g 1000 tomcatgroup
 RUN adduser -D -s / -u 1000 tomcatuser -G tomcatgroup
+RUN mkdir /opt/app/temp-files
 RUN chown -R 1000:1000 /opt/app
 
 USER 1000


### PR DESCRIPTION
Specify a temp folder (not the global one) with access rights defined for the user executing the java process (security issue)