### PR TITLE
fix: loosen types on json schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>4.3.8</revision>
+        <revision>4.3.9</revision>
         <changelist></changelist>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/queen-application/src/main/java/fr/insee/queen/application/campaign/dto/input/CampaignCreationDataV2.java
+++ b/queen-application/src/main/java/fr/insee/queen/application/campaign/dto/input/CampaignCreationDataV2.java
@@ -22,7 +22,7 @@ import java.util.Set;
  * @param metadata campaign metadata
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(name = "CampaignCreation")
+@Schema(name = "CampaignCreationV2")
 public record CampaignCreationDataV2(
         @IdValid
         String id,

--- a/queen-application/src/main/resources/static/v3/schema.metadata.json
+++ b/queen-application/src/main/resources/static/v3/schema.metadata.json
@@ -25,7 +25,7 @@
           "type": "string"
         },
         "value": {
-          "type": ["string", "boolean"]
+          "type": ["string", "boolean", "number"]
         }
       }
     }

--- a/queen-application/src/main/resources/static/v3/schema.variable-type.json
+++ b/queen-application/src/main/resources/static/v3/schema.variable-type.json
@@ -7,28 +7,10 @@
       "type": "string"
     },
     {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    {
       "type": "number"
     },
     {
-      "type": "array",
-      "items": {
-        "type": "number"
-      }
-    },
-    {
       "type": "boolean"
-    },
-    {
-      "type": "array",
-      "items": {
-        "type": "boolean"
-      }
     },
     {
       "type": "null"
@@ -36,7 +18,20 @@
     {
       "type": "array",
       "items": {
-        "type": "null"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
       }
     }
   ]

--- a/queen-application/src/test/java/fr/insee/queen/application/web/validation/json/JsonValidatorComponentTest.java
+++ b/queen-application/src/test/java/fr/insee/queen/application/web/validation/json/JsonValidatorComponentTest.java
@@ -162,7 +162,7 @@ class JsonValidatorComponentTest {
         String metadataJson = JsonTestHelper.getResourceFileAsString("json-schema-validation/metadata/invalid-metadata.json");
         JsonNode metadataNode = mapper.readValue(metadataJson, JsonNode.class);
         Set<ValidationMessage> errors = validatorComponent.validate(SchemaType.METADATA, metadataNode);
-        assertThat(errors).hasSize(6);
+        assertThat(errors).hasSize(5);
 
         ValidationMessage[] messages = errors.toArray(ValidationMessage[]::new);
 
@@ -173,15 +173,12 @@ class JsonValidatorComponentTest {
         assertBadType(error, "$.variables[1].name");
 
         error = messages[2];
-        assertBadType(error, "$.variables[1].value");
-
-        error = messages[3];
         assertRequiredProperty(error, "$.variables[2]", "name");
 
-        error = messages[4];
+        error = messages[3];
         assertRequiredProperty(error, "$.variables[2]", "value");
 
-        error = messages[5];
+        error = messages[4];
         assertForbiddenProperty(error, "$.variables[2]", "forbidden-property");
     }
 

--- a/queen-application/src/test/resources/data/json-schema-validation/metadata/valid-metadata.json
+++ b/queen-application/src/test/resources/data/json-schema-validation/metadata/valid-metadata.json
@@ -38,7 +38,7 @@
     },
     {
       "name":"Enq_AnneeVisa",
-      "value":"2021"
+      "value":2021
     },
     {
       "name":"Loi_statistique",


### PR DESCRIPTION
- allow number in metadata variable value
- allow array of mixed string number boolean null in collected data