### PR TITLE
build: add java tools options with default value in dockerfile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>4.3.15</revision>
+        <revision>4.3.16</revision>
         <changelist></changelist>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>4.3.16</revision>
+        <revision>4.3.17</revision>
         <changelist></changelist>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/queen-application/Dockerfile
+++ b/queen-application/Dockerfile
@@ -1,7 +1,12 @@
 FROM eclipse-temurin:21.0.3_9-jre-alpine
 
+ENV PATH_TO_JAR=/opt/app/app.jar
 WORKDIR /opt/app/
-COPY ./target/*.jar /opt/app/app.jar
+COPY ./target/*.jar $PATH_TO_JAR
+
+ENV JAVA_TOOL_OPTIONS_DEFAULT \
+    -XX:MaxRAMPercentage=75 \
+    -XX:+UseZGC
 
 # Setup a non-root user context (security)
 RUN addgroup -g 1000 tomcatgroup
@@ -11,4 +16,6 @@ RUN chown -R 1000:1000 /opt/app
 
 USER 1000
 
-ENTRYPOINT ["java", "-jar",  "/opt/app/app.jar"]
+ENTRYPOINT [ "/bin/sh", "-c", \
+    "export JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS_DEFAULT $JAVA_TOOL_OPTIONS\"; \
+    exec java -jar $PATH_TO_JAR" ]

--- a/queen-application/Dockerfile
+++ b/queen-application/Dockerfile
@@ -5,8 +5,7 @@ WORKDIR /opt/app/
 COPY ./target/*.jar $PATH_TO_JAR
 
 ENV JAVA_TOOL_OPTIONS_DEFAULT \
-    -XX:MaxRAMPercentage=75 \
-    -XX:+UseZGC
+    -XX:MaxRAMPercentage=75
 
 # Setup a non-root user context (security)
 RUN addgroup -g 1000 tomcatgroup


### PR DESCRIPTION
By default, the memory used by the jvm in kubernetes/docker env is only 25% of available memory.
If you specified 4G as the limit, only 1G can be used.

As you can read in many docs, it's recomanded to set the value at 75%.
You can see this PR for details: https://github.com/InseeFr/Eno/pull/1087