### PR TITLE
feat: Update dependencies and add interrogation_id column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>4.8.3</revision>
+        <revision>4.8.4</revision>
         <changelist></changelist>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
@@ -30,7 +30,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/queen-infra-db/src/main/resources/db/changelog/612_add-interrogation-id.sql
+++ b/queen-infra-db/src/main/resources/db/changelog/612_add-interrogation-id.sql
@@ -1,0 +1,3 @@
+-- Ajout de la colonne interrogation_id à la table survey_unit
+ALTER TABLE survey_unit
+ADD COLUMN interrogation_id UUID;

--- a/queen-infra-db/src/main/resources/db/master.xml
+++ b/queen-infra-db/src/main/resources/db/master.xml
@@ -22,4 +22,5 @@
 	<include file="changelog/600_unique_constraints.xml" relativeToChangelogFile="true"/>
 	<include file="changelog/610_cipher_data.sql" relativeToChangelogFile="true"/>
 	<include file="changelog/611_sensitive_campaign.sql" relativeToChangelogFile="true"/>
+	<include file="changelog/612_add-interrogation-id.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Bumped revision to 4.8.4 and Spring Boot version to 3.4.5 in `pom.xml` for improved dependency management. Added a new database migration script to include the `interrogation_id` column in the `survey_unit` table.