### PR TITLE
fix: revision and modify interrogation_id column type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>4.8.4</revision>
+        <revision>4.8.5</revision>
         <changelist></changelist>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/queen-infra-db/src/main/resources/db/changelog/613_change_type_of_intero_id.sql
+++ b/queen-infra-db/src/main/resources/db/changelog/613_change_type_of_intero_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE survey_unit
+ALTER COLUMN interrogation_id TYPE VARCHAR(255);

--- a/queen-infra-db/src/main/resources/db/master.xml
+++ b/queen-infra-db/src/main/resources/db/master.xml
@@ -23,4 +23,5 @@
 	<include file="changelog/610_cipher_data.sql" relativeToChangelogFile="true"/>
 	<include file="changelog/611_sensitive_campaign.sql" relativeToChangelogFile="true"/>
 	<include file="changelog/612_add-interrogation-id.sql" relativeToChangelogFile="true"/>
+	<include file="changelog/613_change_type_of_intero_id.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Bumped project revision to 4.8.5 in pom.xml. Added a database migration to change the type of `interrogation_id` column in the `survey_unit` table to `VARCHAR(255)`.