### PR TITLE
chore(build): change base image docker eclipse-temurin:21.0.8_9-jre

### DIFF
--- a/.github/workflows/create-snapshot.yml
+++ b/.github/workflows/create-snapshot.yml
@@ -10,10 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
+      clean_branch: ${{ steps.extract_branch.outputs.clean_branch }}
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >>$GITHUB_OUTPUT
+        # create two outputs:
+        # - branch: for checkout
+        # - clean_branch: branch where '/' are replaced by '-' (for tagging docker image)
+        run: |
+          BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
+          echo "branch=$BRANCH_NAME" >>$GITHUB_OUTPUT
+          echo "clean_branch=$(echo $BRANCH_NAME | tr '/' '-')" >>$GITHUB_OUTPUT
         id: extract_branch
 
       - uses: actions/checkout@v4
@@ -54,5 +61,5 @@ jobs:
           name: inseefr/queen-back-office
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          tags: "snapshot-${{ needs.build-snapshot.outputs.branch }}"
+          tags: "snapshot-${{ needs.build-snapshot.outputs.clean_branch }}"
           workdir: queen-application

--- a/queen-application/Dockerfile
+++ b/queen-application/Dockerfile
@@ -7,13 +7,19 @@ COPY ./target/*.jar $PATH_TO_JAR
 ENV JAVA_TOOL_OPTIONS_DEFAULT \
     -XX:MaxRAMPercentage=75
 
-# Setup a non-root user context (security)
-RUN addgroup -g 1000 tomcatgroup
-RUN adduser -D -s / -u 1000 tomcatuser -G tomcatgroup
-RUN mkdir /opt/app/temp-files
-RUN chown -R 1000:1000 /opt/app
 
-USER 1000
+
+ENV JAVA_USER_ID=10001
+ENV JAVA_USER=java
+
+# Setup a non-root user context (security)
+RUN groupadd -g "$JAVA_USER_ID" "$JAVA_USER" && \
+    useradd -r -u "$JAVA_USER_ID" -g "$JAVA_USER" "$JAVA_USER"
+
+RUN mkdir /opt/app/temp-files
+RUN chown -R "$JAVA_USER":"$JAVA_USER" /opt/app
+
+USER $JAVA_USER_ID
 
 ENTRYPOINT [ "/bin/sh", "-c", \
     "export JAVA_TOOL_OPTIONS=\"$JAVA_TOOL_OPTIONS_DEFAULT $JAVA_TOOL_OPTIONS\"; \

--- a/queen-application/Dockerfile
+++ b/queen-application/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.7_6-jre-alpine
+FROM eclipse-temurin:21.0.8_9-jre
 
 ENV PATH_TO_JAR=/opt/app/app.jar
 WORKDIR /opt/app/


### PR DESCRIPTION
Fix this [CVE](https://bugzilla.redhat.com/2380149) (caused by docker image)

- `alpine` tag don't seem to be maintained
- switch to `21.0.8_9-jre` (last update: 17 sept), for `linux/amd64` only 95 MB.
(same as [Pogues-BO](https://github.com/InseeFr/Pogues-Back-Office/blob/main/Dockerfile#L1), [Public-Enemy-BO](https://github.com/InseeFr/Public-Enemy-Back-Office/blob/main/Dockerfile#L1), [Eno](https://github.com/InseeFr/Eno/blob/v3-main/Dockerfile#L1))
- change permission (compatible with this tag)
- Tested in Insee kub env non-root: ✅