### PR TITLE
feat: expose interrogation-questionnaire endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <description>Modules for queen back-office</description>
 
     <properties>
-        <revision>5.8.2</revision>
+        <revision>5.9.0</revision>
         <changelist></changelist>
         <java.version>25</java.version>
         <maven.compiler.source>25</maven.compiler.source>
@@ -34,7 +34,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.12</version>
+        <version>3.5.14</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/queen-application/src/main/java/fr/insee/queen/application/interrogation/controller/InterrogationController.java
+++ b/queen-application/src/main/java/fr/insee/queen/application/interrogation/controller/InterrogationController.java
@@ -5,6 +5,7 @@ import fr.insee.queen.application.configuration.auth.AuthorityPrivileges;
 import fr.insee.queen.application.configuration.auth.AuthorityRoleEnum;
 import fr.insee.queen.application.interrogation.dto.output.InterrogationBySurveyUnitDto;
 import fr.insee.queen.application.interrogation.dto.output.InterrogationStateDto;
+import fr.insee.queen.application.interrogation.dto.output.QuestionnaireLinkDto;
 import fr.insee.queen.application.pilotage.controller.PilotageComponent;
 import fr.insee.queen.application.interrogation.controller.exception.LockedResourceException;
 import fr.insee.queen.application.interrogation.dto.input.StateDataInput;
@@ -280,6 +281,21 @@ public class InterrogationController {
         throw new AccessDeniedException("Not authorized to update interrogation data");
     }
 
+    /**
+     * Get questionnaire links for a list of interrogation IDs
+     *
+     * @param interrogationIds list of interrogation IDs
+     * @return list of questionnaire links
+     */
+    @Operation(summary = "Get questionnaire links for interrogations")
+    @PostMapping("/interrogations/questionnaire-link")
+    @PreAuthorize(AuthorityPrivileges.HAS_INTERVIEWER_PRIVILEGES)
+    public List<QuestionnaireLinkDto> getQuestionnaireLinks(@Valid @RequestBody List<String> interrogationIds) {
+        return interrogationService.findQuestionnaireLinksByInterrogationIds(interrogationIds)
+                .stream()
+                .map(QuestionnaireLinkDto::fromModel)
+                .toList();
+    }
 
     /**
      * Delete an interrogation

--- a/queen-application/src/main/java/fr/insee/queen/application/interrogation/dto/output/QuestionnaireLinkDto.java
+++ b/queen-application/src/main/java/fr/insee/queen/application/interrogation/dto/output/QuestionnaireLinkDto.java
@@ -1,0 +1,20 @@
+package fr.insee.queen.application.interrogation.dto.output;
+
+import fr.insee.queen.domain.interrogation.model.QuestionnaireLink;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "QuestionnaireLink")
+public record QuestionnaireLinkDto(
+        @Schema(description = "Interrogation ID", example = "interro1")
+        String interrogationId,
+
+        @Schema(description = "Questionnaire ID", example = "quest1")
+        String questionnaireId
+) {
+    public static QuestionnaireLinkDto fromModel(QuestionnaireLink questionnaireLink) {
+        return new QuestionnaireLinkDto(
+                questionnaireLink.interrogationId(),
+                questionnaireLink.questionnaireId()
+        );
+    }
+}

--- a/queen-application/src/test/java/fr/insee/queen/application/interrogation/controller/InterrogationControllerTest.java
+++ b/queen-application/src/test/java/fr/insee/queen/application/interrogation/controller/InterrogationControllerTest.java
@@ -8,6 +8,7 @@ import fr.insee.queen.application.interrogation.controller.dummy.MetadataFakeCon
 import fr.insee.queen.application.interrogation.controller.exception.LockedResourceException;
 import fr.insee.queen.application.interrogation.dto.input.*;
 import fr.insee.queen.application.interrogation.dto.output.InterrogationDto;
+import fr.insee.queen.application.interrogation.dto.output.QuestionnaireLinkDto;
 import fr.insee.queen.application.interrogation.service.dummy.StateDataFakeService;
 import fr.insee.queen.application.interrogation.service.dummy.InterrogationFakeService;
 import fr.insee.queen.application.utils.AuthenticatedUserTestHelper;
@@ -409,6 +410,48 @@ class InterrogationControllerTest {
         assertThat(interrogationDto.stateData()).isNull();
         assertThat(interrogationDto.questionnaireId()).isEqualTo(interrogation.questionnaireId());
     }
+
+    @ParameterizedTest
+    @MethodSource("provideQuestionnaireLinkTestCases")
+    @DisplayName("Should return questionnaire links for given interrogation IDs")
+    void testGetQuestionnaireLinks(List<String> inputIds, List<QuestionnaireLinkDto> expectedLinks) {
+        // when
+        List<QuestionnaireLinkDto> questionnaireLinks = interrogationController.getQuestionnaireLinks(inputIds);
+
+        // then
+        assertThat(questionnaireLinks).isNotNull().hasSize(expectedLinks.size());
+
+        assertThat(questionnaireLinks).containsExactlyInAnyOrderElementsOf(expectedLinks);
+    }
+
+    private static Stream<Arguments> provideQuestionnaireLinkTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        List.of(
+                                InterrogationFakeService.INTERROGATION1_ID,
+                                InterrogationFakeService.INTERROGATION2_ID,
+                                InterrogationFakeService.INTERROGATION4_ID
+                        ),
+                        List.of(
+                                new QuestionnaireLinkDto(InterrogationFakeService.INTERROGATION1_ID, InterrogationFakeService.QUESTIONNAIRE1_ID),
+                                new QuestionnaireLinkDto(InterrogationFakeService.INTERROGATION2_ID, InterrogationFakeService.QUESTIONNAIRE1_ID),
+                                new QuestionnaireLinkDto(InterrogationFakeService.INTERROGATION4_ID, InterrogationFakeService.QUESTIONNAIRE2_ID)
+                        )
+                ),
+                Arguments.of(
+                        List.of("unknown-id-1", "unknown-id-2"),
+                        List.of()
+                ),
+                Arguments.of(
+                        List.of(InterrogationFakeService.INTERROGATION1_ID, "unknown-id", InterrogationFakeService.INTERROGATION3_ID),
+                        List.of(
+                                new QuestionnaireLinkDto(InterrogationFakeService.INTERROGATION1_ID, InterrogationFakeService.QUESTIONNAIRE1_ID),
+                                new QuestionnaireLinkDto(InterrogationFakeService.INTERROGATION3_ID, InterrogationFakeService.QUESTIONNAIRE1_ID)
+                        )
+                )
+        );
+    }
+
 
     @Test
     @DisplayName("Should return interrogations by survey-unit")

--- a/queen-application/src/test/java/fr/insee/queen/application/interrogation/controller/InterrogationControllerTest.java
+++ b/queen-application/src/test/java/fr/insee/queen/application/interrogation/controller/InterrogationControllerTest.java
@@ -419,9 +419,9 @@ class InterrogationControllerTest {
         List<QuestionnaireLinkDto> questionnaireLinks = interrogationController.getQuestionnaireLinks(inputIds);
 
         // then
-        assertThat(questionnaireLinks).isNotNull().hasSize(expectedLinks.size());
-
-        assertThat(questionnaireLinks).containsExactlyInAnyOrderElementsOf(expectedLinks);
+        assertThat(questionnaireLinks)
+                .isNotNull().hasSize(expectedLinks.size())
+                .containsExactlyInAnyOrderElementsOf(expectedLinks);
     }
 
     private static Stream<Arguments> provideQuestionnaireLinkTestCases() {

--- a/queen-application/src/test/java/fr/insee/queen/application/interrogation/service/dummy/InterrogationFakeService.java
+++ b/queen-application/src/test/java/fr/insee/queen/application/interrogation/service/dummy/InterrogationFakeService.java
@@ -200,4 +200,13 @@ public class InterrogationFakeService implements InterrogationService {
     public List<InterrogationState> getInterrogations(String campaignId, StateDataType stateDataType) {
         return null;
     }
+
+    @Override
+    public List<QuestionnaireLink> findQuestionnaireLinksByInterrogationIds(List<String> interrogationIds) {
+        return interrogationSummaries
+                .stream()
+                .filter(summary -> interrogationIds.contains(summary.id()))
+                .map(summary -> new QuestionnaireLink(summary.id(), summary.questionnaireId()))
+                .toList();
+    }
 }

--- a/queen-application/src/test/java/fr/insee/queen/application/interrogation/service/dummy/InterrogationFakeService.java
+++ b/queen-application/src/test/java/fr/insee/queen/application/interrogation/service/dummy/InterrogationFakeService.java
@@ -23,6 +23,9 @@ public class InterrogationFakeService implements InterrogationService {
     public static final String INTERROGATION5_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa05";
     public static final String INTERROGATION6_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa06";
 
+    public static final String QUESTIONNAIRE1_ID = "questionnaire-id-1";
+    public static final String QUESTIONNAIRE2_ID = "questionnaire-id-2";
+
     @Getter
     private final List<Interrogation> interrogations;
     @Getter
@@ -48,12 +51,12 @@ public class InterrogationFakeService implements InterrogationService {
         CampaignSummary normalCampaign = new CampaignSummary("campaign-id", "campaign-label", CampaignSensitivity.NORMAL);
         CampaignSummary sensitiveCampaign = new CampaignSummary("campaign-id2", "campaign-label2", CampaignSensitivity.SENSITIVE);
         interrogationSummaries = List.of(
-                new InterrogationSummary(INTERROGATION1_ID, "survey-unit-id1", "questionnaire-id", normalCampaign),
-                new InterrogationSummary(INTERROGATION2_ID, "survey-unit-id2", "questionnaire-id", normalCampaign),
-                new InterrogationSummary(INTERROGATION3_ID, "survey-unit-id3", "questionnaire-id", sensitiveCampaign),
-                new InterrogationSummary(INTERROGATION4_ID, "survey-unit-id4", "questionnaire-id", sensitiveCampaign),
-                new InterrogationSummary(INTERROGATION5_ID, "survey-unit-id5", "questionnaire-id", sensitiveCampaign),
-                new InterrogationSummary(INTERROGATION6_ID, "survey-unit-id6", "questionnaire-id", sensitiveCampaign)
+                new InterrogationSummary(INTERROGATION1_ID, "survey-unit-id1", QUESTIONNAIRE1_ID, normalCampaign),
+                new InterrogationSummary(INTERROGATION2_ID, "survey-unit-id2", QUESTIONNAIRE1_ID, normalCampaign),
+                new InterrogationSummary(INTERROGATION3_ID, "survey-unit-id3", QUESTIONNAIRE1_ID, sensitiveCampaign),
+                new InterrogationSummary(INTERROGATION4_ID, "survey-unit-id4", QUESTIONNAIRE2_ID, sensitiveCampaign),
+                new InterrogationSummary(INTERROGATION5_ID, "survey-unit-id5", QUESTIONNAIRE2_ID, sensitiveCampaign),
+                new InterrogationSummary(INTERROGATION6_ID, "survey-unit-id6", QUESTIONNAIRE2_ID, sensitiveCampaign)
         );
 
         ObjectNode data = JsonNodeFactory.instance.objectNode();

--- a/queen-domain-pilotage/src/test/java/fr/insee/queen/domain/interrogation/service/dummy/InterrogationFakeService.java
+++ b/queen-domain-pilotage/src/test/java/fr/insee/queen/domain/interrogation/service/dummy/InterrogationFakeService.java
@@ -139,4 +139,13 @@ public class InterrogationFakeService implements InterrogationService {
     public List<InterrogationState> getInterrogations(String campaignId, StateDataType stateDataType) {
         return null;
     }
+
+    @Override
+    public List<QuestionnaireLink> findQuestionnaireLinksByInterrogationIds(List<String> interrogationIds) {
+        return interrogationSummaries
+                .stream()
+                .filter(summary -> interrogationIds.contains(summary.id()))
+                .map(summary -> new QuestionnaireLink(summary.id(), summary.questionnaireId()))
+                .toList();
+    }
 }

--- a/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/model/QuestionnaireLink.java
+++ b/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/model/QuestionnaireLink.java
@@ -1,0 +1,7 @@
+package fr.insee.queen.domain.interrogation.model;
+
+public record QuestionnaireLink(
+        String interrogationId,
+        String questionnaireId
+) {
+}

--- a/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/service/InterrogationApiService.java
+++ b/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/service/InterrogationApiService.java
@@ -200,6 +200,13 @@ public class InterrogationApiService implements InterrogationService {
     }
 
     @Override
+    public List<QuestionnaireLink> findQuestionnaireLinksByInterrogationIds(List<String> interrogationIds) {
+        return interrogationRepository.findAllSummaryByIdIn(interrogationIds).stream()
+                .map(summary -> new QuestionnaireLink(summary.id(), summary.questionnaireId()))
+                .toList();
+    }
+
+    @Override
     public InterrogationSummary getSummaryById(String interrogationId) {
         return findSummaryById(interrogationId)
                 .orElseThrow(() -> new EntityNotFoundException(String.format(NOT_FOUND_MESSAGE, interrogationId)));

--- a/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/service/InterrogationService.java
+++ b/queen-domain/src/main/java/fr/insee/queen/domain/interrogation/service/InterrogationService.java
@@ -47,4 +47,6 @@ public interface InterrogationService {
     List<Interrogation> findAllInterrogations();
 
     List<InterrogationState> getInterrogations(String campaignId, StateDataType stateDataType);
+
+    List<QuestionnaireLink> findQuestionnaireLinksByInterrogationIds(List<String> interrogationIds);
 }

--- a/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/infrastructure/dummy/InterrogationFakeDao.java
+++ b/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/infrastructure/dummy/InterrogationFakeDao.java
@@ -46,7 +46,10 @@ public class InterrogationFakeDao implements InterrogationRepository {
 
     @Override
     public List<InterrogationSummary> findAllSummaryByIdIn(List<String> interrogationIds) {
-        return null;
+            return interrogationSummaries
+                    .stream()
+                    .filter(summary -> interrogationIds.contains(summary.id()))
+                    .toList();
     }
 
     @Override

--- a/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/InterrogationApiServiceTest.java
+++ b/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/InterrogationApiServiceTest.java
@@ -263,11 +263,12 @@ class InterrogationApiServiceTest {
         List<QuestionnaireLink> result = interrogationApiService.findQuestionnaireLinksByInterrogationIds(interrogationIds);
 
         // Then
-        assertThat(result).hasSize(3);
-        assertThat(result).containsExactlyInAnyOrder(
-                new QuestionnaireLink("interro1", "quest1"),
-                new QuestionnaireLink("interro2", "quest2"),
-                new QuestionnaireLink("interro3", "quest1")
+        assertThat(result)
+                .hasSize(3)
+                .containsExactlyInAnyOrder(
+                        new QuestionnaireLink("interro1", "quest1"),
+                        new QuestionnaireLink("interro2", "quest2"),
+                        new QuestionnaireLink("interro3", "quest1")
         );
     }
 
@@ -285,10 +286,11 @@ class InterrogationApiServiceTest {
         List<QuestionnaireLink> result = interrogationApiService.findQuestionnaireLinksByInterrogationIds(interrogationIds);
 
         // Then
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactlyInAnyOrder(
-                new QuestionnaireLink("interro1", "quest1"),
-                new QuestionnaireLink("interro2", "quest2")
+        assertThat(result)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(
+                        new QuestionnaireLink("interro1", "quest1"),
+                        new QuestionnaireLink("interro2", "quest2")
         );
     }
 

--- a/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/InterrogationApiServiceTest.java
+++ b/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/InterrogationApiServiceTest.java
@@ -247,4 +247,62 @@ class InterrogationApiServiceTest {
         assertThat(interrogationSummaries).hasSize(1);
         assertThat(interrogationSummaries.getFirst().surveyUnitId()).isEqualTo("survey-unit-id1");
     }
+
+    @Test
+    @DisplayName("Retrieve questionnaire links for interrogation IDs")
+    void findQuestionnaireLinksByInterrogationIds_should_return_questionnaire_links() {
+        // Given
+        List<String> interrogationIds = List.of("interro1", "interro2", "interro3");
+        CampaignSummary campaignSummary = new CampaignSummary("campaignId", "label", null);
+        InterrogationSummary summary1 = new InterrogationSummary("interro1", "su1", "quest1", campaignSummary);
+        InterrogationSummary summary2 = new InterrogationSummary("interro2", "su2", "quest2", campaignSummary);
+        InterrogationSummary summary3 = new InterrogationSummary("interro3", "su3", "quest1", campaignSummary);
+        interrogationFakeDao.setInterrogationSummaries(List.of(summary1, summary2, summary3));
+
+        // When
+        List<QuestionnaireLink> result = interrogationApiService.findQuestionnaireLinksByInterrogationIds(interrogationIds);
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactlyInAnyOrder(
+                new QuestionnaireLink("interro1", "quest1"),
+                new QuestionnaireLink("interro2", "quest2"),
+                new QuestionnaireLink("interro3", "quest1")
+        );
+    }
+
+    @Test
+    @DisplayName("Filter out non-existent interrogations when retrieving questionnaire links")
+    void findQuestionnaireLinksByInterrogationIds_should_filter_out_nonexistent_interrogations() {
+        // Given
+        List<String> interrogationIds = List.of("interro1", "nonexistent", "interro2");
+        CampaignSummary campaignSummary = new CampaignSummary("campaignId", "label", null);
+        InterrogationSummary summary1 = new InterrogationSummary("interro1", "su1", "quest1", campaignSummary);
+        InterrogationSummary summary2 = new InterrogationSummary("interro2", "su2", "quest2", campaignSummary);
+        interrogationFakeDao.setInterrogationSummaries(List.of(summary1, summary2));
+
+        // When
+        List<QuestionnaireLink> result = interrogationApiService.findQuestionnaireLinksByInterrogationIds(interrogationIds);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactlyInAnyOrder(
+                new QuestionnaireLink("interro1", "quest1"),
+                new QuestionnaireLink("interro2", "quest2")
+        );
+    }
+
+    @Test
+    @DisplayName("Return empty list for empty input when retrieving questionnaire links")
+    void findQuestionnaireLinksByInterrogationIds_should_return_empty_list_for_empty_input() {
+        // Given
+        List<String> interrogationIds = List.of();
+        interrogationFakeDao.setInterrogationSummaries(List.of());
+
+        // When
+        List<QuestionnaireLink> result = interrogationApiService.findQuestionnaireLinksByInterrogationIds(interrogationIds);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
 }

--- a/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/dummy/InterrogationFakeService.java
+++ b/queen-domain/src/test/java/fr/insee/queen/domain/interrogation/service/dummy/InterrogationFakeService.java
@@ -141,4 +141,13 @@ public class InterrogationFakeService implements InterrogationService {
     public List<InterrogationState> getInterrogations(String campaignId, StateDataType stateDataType) {
         return null;
     }
+
+    @Override
+    public List<QuestionnaireLink> findQuestionnaireLinksByInterrogationIds(List<String> interrogationIds) {
+        return interrogationSummaries
+                .stream()
+                .filter(summary -> interrogationIds.contains(summary.id()))
+                .map(summary -> new QuestionnaireLink(summary.id(), summary.questionnaireId()))
+                .toList();
+    }
 }


### PR DESCRIPTION
when posting list of interrogation ID, API returns :
```json
[
  {
    "interrogationId" : "interro1,
    "questionnaireId" : "qm1
  },
  {
    "interrogationId" : "interro2,
    "questionnaireId" : "qm1
  },

  {
    "interrogationId" : "interro3,
    "questionnaireId" : "qm2
  }
]
```

rules :
 - return IDs tuple for current DB interrogations
 - missing interrogations are ignored